### PR TITLE
Fix duplicate table retrieval and finish invoice link

### DIFF
--- a/restaurant_management/api/pos_restaurant.py
+++ b/restaurant_management/api/pos_restaurant.py
@@ -1,6 +1,5 @@
 import frappe
 from frappe import _
-from frappe.utils import flt
 import json
 
 
@@ -35,34 +34,6 @@ def get_tables(pos_profile=None):
         allowed_branches = get_allowed_branches_for_user()
         if allowed_branches:
             filters["branch_code"] = ["in", allowed_branches]
-    
-    # Get tables
-    tables = frappe.get_all(
-        "Table",
-        filters=filters,
-        fields=["name", "table_number", "status", "current_pos_order", "branch_code"],
-        order_by="table_number"
-    )
-    
-    return tables
-    """
-    Get tables for POS interface
-    
-    Args:
-        pos_profile (str): POS Profile name to filter tables by branch
-        
-    Returns:
-        List of tables with status
-    """
-    if not pos_profile:
-        return []
-    
-    # Get branch code from POS profile
-    branch_code = frappe.db.get_value("POS Profile", pos_profile, "branch_code")
-    
-    filters = {}
-    if branch_code:
-        filters["branch_code"] = branch_code
     
     # Get tables
     tables = frappe.get_all(
@@ -453,17 +424,19 @@ def link_pos_invoice_to_sales_order(pos_invoice, sales_order):
         sales_order (str): Sales Order name
     """
     if not pos_invoice or not sales_order:
-        return
-    
+        return {"success": False, "message": _("POS Invoice or Sales Order not specified")}
+
     try:
         # Get POS Invoice
         pos_doc = frappe.get_doc("POS Invoice", pos_invoice)
-        
+
         # Check if it already has a Sales Order reference
         if hasattr(pos_doc, "sales_order") and not pos_doc.sales_order:
             pos_doc.sales_order = sales_order
             pos_doc.save()
-            
             frappe.db.commit()
+
+        return {"success": True}
     except Exception as e:
         frappe.log_error(frappe.get_traceback(), _("Error linking POS Invoice to Sales Order"))
+        return {"success": False, "message": str(e)}


### PR DESCRIPTION
## Summary
- clean imports in `pos_restaurant.py`
- remove duplicate implementation of `get_tables`
- finish `link_pos_invoice_to_sales_order` with error handling and newline

## Testing
- `python -m py_compile restaurant_management/api/pos_restaurant.py`

------
https://chatgpt.com/codex/tasks/task_e_686923fc7c38832ca856d9413af9ce28