### PR TITLE
Fix waiter order branch fields

### DIFF
--- a/restaurant_management/www/waiter_order.html
+++ b/restaurant_management/www/waiter_order.html
@@ -24,7 +24,7 @@
     <select id="branch-selector" class="w-full md:w-64 p-2 border rounded-md">
       {% for branch in branches %}
       <option value="{{ branch.branch_code }}" {% if default_branch and branch.branch_code == default_branch.branch_code %}selected{% endif %}>
-        {{ branch.branch_name or branch.name }}
+        {{ branch.name }}
       </option>
       {% endfor %}
     </select>

--- a/restaurant_management/www/waiter_order.py
+++ b/restaurant_management/www/waiter_order.py
@@ -18,7 +18,7 @@ def get_context(context: Dict[str, Any]) -> None:
         None: The function modifies the context dict in-place
     
     Raises:
-        frappe.PageError: If there's a critical error loading the page data
+        frappe.ValidationError: If there's a critical error loading the page data
     """
     try:
         # Set page title
@@ -27,7 +27,7 @@ def get_context(context: Dict[str, Any]) -> None:
         # Fetch all branches
         all_branches = frappe.get_all(
             'Branch',
-            fields=['name', 'branch_code', 'branch_name'],
+            fields=['name', 'branch_code'],
             filters={'is_active': 1}
         )
         
@@ -50,4 +50,4 @@ def get_context(context: Dict[str, Any]) -> None:
             message=f"Error loading waiter order page: {str(e)}",
             title="Waiter Order Page Error"
         )
-        raise frappe.PageError("Unable to load waiter order page. Please check error logs.")
+        raise frappe.ValidationError("Unable to load waiter order page. Please check error logs.")


### PR DESCRIPTION
## Summary
- request only existing Branch fields in waiter order context
- drop deprecated `branch_name` from the waiter order template
- raise `frappe.ValidationError` when the page fails to load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68697ead0fcc832c9b2a58668495eb71