### PR TITLE
Fix year display

### DIFF
--- a/restaurant_management/www/station_display.html
+++ b/restaurant_management/www/station_display.html
@@ -68,7 +68,7 @@
   <!-- Footer -->
   <footer class="bg-white mt-auto">
     <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
-      <p class="text-sm text-gray-500 text-center">&copy; {% now 'Y' %} Restaurant Management System</p>
+      <p class="text-sm text-gray-500 text-center">&copy; {{ frappe.utils.now_datetime().year }} Restaurant Management System</p>
     </div>
   </footer>
   


### PR DESCRIPTION
## Summary
- show the current year using Frappe's datetime util

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68697eaf1fcc832cab461a22228bb337