### PR TITLE
Remove unused variable

### DIFF
--- a/restaurant_management/setup/create_demo_data.py
+++ b/restaurant_management/setup/create_demo_data.py
@@ -105,9 +105,6 @@ def import_fixture_data():
                     if doc_data.get("doctype") == "Item" and doc_data.get("variant_of"):
                         name = doc_data.get("name")
                         try:
-                            # Store standard rate for later use
-                            standard_rate = doc_data.get("standard_rate")
-
                             # Remove standard_rate to prevent issues
                             if "standard_rate" in doc_data:
                                 doc_data_copy = doc_data.copy()


### PR DESCRIPTION
## Summary
- remove leftover `standard_rate` from `create_demo_data`

## Testing
- `python -m compileall -q restaurant_management`


------
https://chatgpt.com/codex/tasks/task_e_68727760eb1c832cba21db33260f2845