### PR TITLE
Fix missing boot_session module

### DIFF
--- a/restaurant_management/startup/boot_session.py
+++ b/restaurant_management/startup/boot_session.py
@@ -1,0 +1,13 @@
+"""Session boot hooks for Restaurant Management app."""
+
+def boot_session(bootinfo):
+    """Modify bootinfo at session start.
+
+    This function is called by Frappe/ERPNext during the boot process. It can
+    be used to inject additional data into the bootinfo dictionary that is
+    sent to the client when a user logs in.
+
+    For now the implementation simply returns the bootinfo unchanged.
+    """
+    return bootinfo
+


### PR DESCRIPTION
## Summary
- add `startup` package with `boot_session` implementation
- keep hooks referencing `boot_session`

## Testing
- `python -c "import restaurant_management.startup.boot_session"`


------
https://chatgpt.com/codex/tasks/task_e_687277624d54832ca57ec352753acd3e