### PR TITLE
Improve installation logging

### DIFF
--- a/restaurant_management/hooks.py
+++ b/restaurant_management/hooks.py
@@ -139,7 +139,19 @@ doctype_js = {
 }
 
 # Install
-after_install = "restaurant_management.setup.install.after_install"
+
+import frappe
+
+
+def safe_after_install():
+    try:
+        from .setup.install import after_install as _after_install
+        _after_install()
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "restaurant_management.safe_after_install")
+
+
+after_install = safe_after_install
 
 # App setup events
 boot_session = "restaurant_management.startup.boot_session"

--- a/restaurant_management/setup/install.py
+++ b/restaurant_management/setup/install.py
@@ -1,9 +1,16 @@
 import frappe
 
+
 def after_install():
     """Run after app installation"""
     frappe.db.commit()
     frappe.clear_cache()
-    
-    print("Restaurant Management app installed successfully!")
-    print("To create demo data, run: bench --site [sitename] execute restaurant_management.setup.create_demo_data.create_demo_data")
+
+    logger = frappe.logger()
+    try:
+        logger.info("Restaurant Management app installed successfully!")
+        logger.info(
+            "To create demo data, run: bench --site [sitename] execute restaurant_management.setup.create_demo_data.create_demo_data"
+        )
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "restaurant_management.after_install")


### PR DESCRIPTION
## Summary
- log install messages via `frappe.logger()` instead of `print`
- capture logging failures using `frappe.log_error`
- wrap `after_install` hook to safely log issues

## Testing
- `pytest -q`
- `python -m compileall -q restaurant_management`

------
https://chatgpt.com/codex/tasks/task_e_68727763cc90832cab1822291078e912