### PR TITLE
Fix bench start block

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Restaurant Management System for ERPNext
    ```
 4. Start the development server.
    ```bash
-bench start
-```
+   bench start
+   ```
 
 5. Import fixtures
    ```bash


### PR DESCRIPTION
## Summary
- clean up README example for starting the dev server

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement frappe>=15.0.0)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68731e72a53c832c8f31f851cddcdb6a