### PR TITLE
Fix boot_session hook path

### DIFF
--- a/restaurant_management/hooks.py
+++ b/restaurant_management/hooks.py
@@ -155,4 +155,4 @@ def safe_after_install():
 after_install = safe_after_install
 
 # App setup events
-boot_session = "restaurant_management.startup.boot_session"
+boot_session = "restaurant_management.startup.boot_session.boot_session"


### PR DESCRIPTION
## Summary
- fix path for `boot_session` hook so Frappe can import correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732bb35958832cbce416b57c03e78e