### PR TITLE
Fix table field names for seating capacity and order alias

### DIFF
--- a/restaurant_management/www/internal_ui/table_display.html
+++ b/restaurant_management/www/internal_ui/table_display.html
@@ -56,7 +56,7 @@
             
             <div class="card-body table-summary">
               <div class="summary-stat">
-                <div class="stat-value">{{ table.capacity or 0 }}</div>
+                <div class="stat-value">{{ table.seating_capacity or 0 }}</div>
                 <div class="stat-label">Capacity</div>
               </div>
               

--- a/restaurant_management/www/internal_ui/table_display.py
+++ b/restaurant_management/www/internal_ui/table_display.py
@@ -42,8 +42,8 @@ def get_context(context=None):
         tables = frappe.get_all(
             'Table',
             fields=[
-                'name', 'table_number', 'capacity', 'status',
-                'branch', 'current_order', 'occupied_seats'
+                'name', 'table_number', 'seating_capacity', 'status',
+                'branch', 'current_pos_order as current_order', 'occupied_seats'
             ]
         ) or []
         

--- a/restaurant_management/www/internal_ui/waiter_order.py
+++ b/restaurant_management/www/internal_ui/waiter_order.py
@@ -54,8 +54,8 @@ def get_context(context):
         tables = frappe.get_all(
             'Table',
             fields=[
-                'name', 'table_number', 'capacity', 'status',
-                'branch', 'current_order'
+                'name', 'table_number', 'seating_capacity', 'status',
+                'branch', 'current_pos_order as current_order'
             ]
         ) or []
         


### PR DESCRIPTION
## Summary
- use `seating_capacity` for tables
- alias `current_pos_order` to `current_order`
- update table overview template to show seating capacity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687514496c38832c9061fd8506e94324