### PR TITLE
Handle optional occupied_seats field

### DIFF
--- a/restaurant_management/www/internal_ui/table_display.py
+++ b/restaurant_management/www/internal_ui/table_display.py
@@ -38,14 +38,30 @@ def get_context(context=None):
         # Set default branch (first available or None)
         default_branch = branches[0] if branches else None
         
+        # Determine available fields for the Table DocType
+        meta = frappe.get_meta("Table")
+
+        table_fields = [
+            "name",
+            "table_number",
+            "seating_capacity",
+            "status",
+            "branch",
+            "current_pos_order as current_order",
+        ]
+
+        if meta.has_field("occupied_seats"):
+            table_fields.append("occupied_seats")
+
         # Get all tables with relevant fields
         tables = frappe.get_all(
-            'Table',
-            fields=[
-                'name', 'table_number', 'seating_capacity', 'status',
-                'branch', 'current_pos_order as current_order', 'occupied_seats'
-            ]
+            "Table",
+            fields=table_fields
         ) or []
+
+        # Ensure occupied_seats exists in every table dict
+        for table in tables:
+            table["occupied_seats"] = table.get("occupied_seats", 0)
         
         # Add data to context
         context.branches = branches


### PR DESCRIPTION
## Summary
- fetch table meta to validate fields
- only query for available table fields
- default `occupied_seats` to 0 if column is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687520bc1584832ca54ad39de9ca5f3f