### PR TITLE
Update templates to standalone HTML

### DIFF
--- a/restaurant_management/www/internal_ui/station_display.html
+++ b/restaurant_management/www/internal_ui/station_display.html
@@ -1,22 +1,15 @@
-{% extends "templates/web.html" %}
-
-{% block title %}Station Display{% endblock %}
-
-{% block header %}
-{# Empty override to remove default header #}
-{% endblock %}
-
-{% block head_include %}
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-{% endblock %}
-
-{% block page_content %}
-<div class="min-h-screen flex flex-col bg-gray-100">
-  <!-- Header -->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex">
+  <title>Station Display</title>
+</head>
+<body class="min-h-screen flex flex-col bg-gray-100">
   <header class="bg-gray-800 text-white shadow">
     <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8 flex flex-wrap justify-between items-center">
       <h1 class="text-xl font-bold">Kitchen Station Display</h1>
-      
       <div class="flex flex-wrap gap-4 items-center mt-2 sm:mt-0">
         <div class="flex items-center gap-2">
           <label for="kitchen-station" class="font-medium text-sm">Station:</label>
@@ -29,7 +22,6 @@
             {% endif %}
           </select>
         </div>
-        
         <div class="flex items-center gap-2">
           <label for="branch-code" class="font-medium text-sm">Branch:</label>
           <select id="branch-code" class="rounded bg-gray-700 border-gray-600 text-white py-1 px-3 text-sm">
@@ -43,15 +35,12 @@
             {% endif %}
           </select>
         </div>
-        
         <div class="text-gray-300 text-sm flex items-center">
           Auto-refresh in <span id="refresh-countdown" class="text-sm ml-1 font-medium">10</span>s
         </div>
       </div>
     </div>
   </header>
-
-  <!-- Main Content -->
   <main class="flex-1 max-w-7xl mx-auto w-full px-4 py-6 sm:px-6 lg:px-8">
     {% if error_message %}
       <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-4">
@@ -61,11 +50,9 @@
         {% endif %}
       </div>
     {% endif %}
-    
     {% if not has_branches and not has_stations %}
       <div class="bg-white rounded-lg shadow p-6 text-center">
         <p class="text-gray-600 mb-4">No data available. Please check your configuration or permissions.</p>
-        
         {% if is_guest %}
         <p class="text-gray-600">
           You're currently viewing as a guest. This page may require login for full functionality.
@@ -78,7 +65,6 @@
         <div class="px-4 py-5 sm:px-6 border-b border-gray-200">
           <h2 class="text-lg font-medium text-gray-900">Order Queue</h2>
         </div>
-        
         <div class="overflow-x-auto">
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-700 text-white">
@@ -106,35 +92,28 @@
       </div>
     {% endif %}
   </main>
-  
-  <!-- Footer -->
   <footer class="bg-white mt-auto">
     <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
       <p class="text-sm text-gray-500 text-center">&copy; {{ frappe.utils.now_datetime().year }} Restaurant Management System</p>
     </div>
   </footer>
-  
-  <!-- Loading Overlay -->
   <div id="kds-loading" class="fixed inset-0 hidden items-center justify-center bg-black/60 z-50">
     <div class="bg-white p-6 rounded-lg shadow-lg text-center">
       <div class="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-indigo-500 mx-auto"></div>
       <p class="mt-4 text-gray-700">Loading...</p>
     </div>
   </div>
-</div>
-{% endblock %}
-
-{% block script %}
-<script>
-  window.kdsContext = {
-    csrfToken: "{{ csrf_token or '' }}",
-    defaultBranch: {% if default_branch %}{{ default_branch | tojson }}{% else %}null{% endif %},
-    hasStations: {{ has_stations | tojson }},
-    hasBranches: {{ has_branches | tojson }},
-    stationCount: {{ (kitchen_stations|length) if kitchen_stations else 0 }},
-    branchCount: {{ (branches|length) if branches else 0 }},
-    isGuest: {{ is_guest | tojson }}
-  };
-</script>
-<script defer src="/assets/restaurant_management/js/station_display.js"></script>
-{% endblock %}
+  <script>
+    window.kdsContext = {
+      csrfToken: "{{ csrf_token or '' }}",
+      defaultBranch: {% if default_branch %}{{ default_branch | tojson }}{% else %}null{% endif %},
+      hasStations: {{ has_stations | tojson }},
+      hasBranches: {{ has_branches | tojson }},
+      stationCount: {{ (kitchen_stations|length) if kitchen_stations else 0 }},
+      branchCount: {{ (branches|length) if branches else 0 }},
+      isGuest: {{ is_guest | tojson }}
+    };
+  </script>
+  <script defer src="/assets/restaurant_management/js/station_display.js"></script>
+</body>
+</html>

--- a/restaurant_management/www/internal_ui/table_display.html
+++ b/restaurant_management/www/internal_ui/table_display.html
@@ -1,111 +1,96 @@
-{% extends "templates/web.html" %}
-
-{% block title %}Table Overview{% endblock %}
-
-{% block header %}
-{# Empty override to remove default header #}
-{% endblock %}
-
-{% block style %}
-<link rel="stylesheet" href="/assets/restaurant_management/css/table_display.css">
-{% endblock %}
-
-{% block page_content %}
-<div class="overview-container">
-  <!-- Header with filters -->
-  <div class="overview-header">
-    <div class="overview-title">Table Overview</div>
-    
-    <div class="overview-controls">
-      <div class="branch-filter">
-        <label for="branch-code">Branch:</label>
-        <select id="branch-code" class="branch-select">
-          <option value="">All Branches</option>
-          {% if branches %}
-            {% for branch in branches %}
-              <option value="{{ branch.branch_code or '' }}" {% if default_branch and branch.branch_code and default_branch.branch_code and branch.branch_code == default_branch.branch_code %}selected{% endif %}>
-                {{ branch.name or 'Unnamed Branch' }}
-              </option>
-            {% endfor %}
-          {% endif %}
-        </select>
-      </div>
-      
-      <div class="refresh-info">
-        Auto-refresh: <span id="refresh-countdown">30</span>s
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex">
+  <title>Table Overview</title>
+  <link rel="stylesheet" href="/assets/restaurant_management/css/table_display.css">
+</head>
+<body>
+  <main class="overview-container">
+    <!-- Header with filters -->
+    <div class="overview-header">
+      <div class="overview-title">Table Overview</div>
+      <div class="overview-controls">
+        <div class="branch-filter">
+          <label for="branch-code">Branch:</label>
+          <select id="branch-code" class="branch-select">
+            <option value="">All Branches</option>
+            {% if branches %}
+              {% for branch in branches %}
+                <option value="{{ branch.branch_code or '' }}" {% if default_branch and branch.branch_code and default_branch.branch_code and branch.branch_code == default_branch.branch_code %}selected{% endif %}>
+                  {{ branch.name or 'Unnamed Branch' }}
+                </option>
+              {% endfor %}
+            {% endif %}
+          </select>
+        </div>
+        <div class="refresh-info">
+          Auto-refresh: <span id="refresh-countdown">30</span>s
+        </div>
       </div>
     </div>
-  </div>
-  
-  <!-- Main content with table cards -->
-  <div class="overview-content">
-    {% if error_message %}
-      <div class="alert alert-warning">
-        {{ error_message }}
-      </div>
-    {% endif %}
-    
-    <div class="tables-grid" id="tables-container">
-      {% if tables and tables|length > 0 %}
-        {% for table in tables %}
-          <div class="card table-card" data-table-id="{{ table.name or '' }}">
-            <div class="card-header table-header">
-              <div class="table-number">Table {{ table.table_number or '?' }}</div>
-              <div class="table-status status-{{ (table.status or '')|lower|replace(' ', '-') }}">{{ table.status or 'Unknown' }}</div>
-            </div>
-            
-            <div class="card-body table-summary">
-              <div class="summary-stat">
-                <div class="stat-value">{{ table.seating_capacity or 0 }}</div>
-                <div class="stat-label">Capacity</div>
+    <!-- Main content with table cards -->
+    <div class="overview-content">
+      {% if error_message %}
+        <div class="alert alert-warning">
+          {{ error_message }}
+        </div>
+      {% endif %}
+      <div class="tables-grid" id="tables-container">
+        {% if tables and tables|length > 0 %}
+          {% for table in tables %}
+            <div class="card table-card" data-table-id="{{ table.name or '' }}">
+              <div class="card-header table-header">
+                <div class="table-number">Table {{ table.table_number or '?' }}</div>
+                <div class="table-status status-{{ (table.status or '')|lower|replace(' ', '-') }}">{{ table.status or 'Unknown' }}</div>
               </div>
-              
-              <div class="summary-stat">
-                <div class="stat-value">{{ table.occupied_seats or 0 }}</div>
-                <div class="stat-label">Occupied</div>
+              <div class="card-body table-summary">
+                <div class="summary-stat">
+                  <div class="stat-value">{{ table.seating_capacity or 0 }}</div>
+                  <div class="stat-label">Capacity</div>
+                </div>
+                <div class="summary-stat">
+                  <div class="stat-value">{{ table.occupied_seats or 0 }}</div>
+                  <div class="stat-label">Occupied</div>
+                </div>
+                {% if table.branch %}
+                <div class="summary-stat">
+                  <div class="stat-value">{{ table.branch }}</div>
+                  <div class="stat-label">Branch</div>
+                </div>
+                {% endif %}
               </div>
-              
-              {% if table.branch %}
-              <div class="summary-stat">
-                <div class="stat-value">{{ table.branch }}</div>
-                <div class="stat-label">Branch</div>
+              {% if table.current_order %}
+              <div class="card-footer text-end">
+                <small class="text-muted">Order: {{ table.current_order }}</small>
               </div>
               {% endif %}
             </div>
-            
-            {% if table.current_order %}
-            <div class="card-footer text-end">
-              <small class="text-muted">Order: {{ table.current_order }}</small>
-            </div>
-            {% endif %}
+          {% endfor %}
+        {% else %}
+          <div class="empty-state">
+            <p>No tables found. {% if not has_branches %}Please create branches and tables first.{% endif %}</p>
           </div>
-        {% endfor %}
-      {% else %}
-        <div class="empty-state">
-          <p>No tables found. {% if not has_branches %}Please create branches and tables first.{% endif %}</p>
-        </div>
-      {% endif %}
+        {% endif %}
+      </div>
     </div>
-  </div>
-  
-  <!-- Loading overlay -->
-  <div id="loading-overlay" class="loading-overlay" style="display: none;">
-    <div class="spinner"></div>
-    <div>Loading...</div>
-  </div>
-</div>
-{% endblock %}
-
-{% block script %}
-<script>
-  // Context variables made available to JavaScript
-  window.tableOverviewContext = {
-    csrfToken: "{{ csrf_token or '' }}",
-    defaultBranch: {% if default_branch %}{{ default_branch | tojson }}{% else %}null{% endif %},
-    hasBranches: {{ has_branches | tojson }},
-    branchCount: {{ (branches|length) if branches else 0 }},
-    tableCount: {{ (tables|length) if tables else 0 }}
-  };
-</script>
-<script src="/assets/restaurant_management/js/table_display.js"></script>
-{% endblock %}
+    <!-- Loading overlay -->
+    <div id="loading-overlay" class="loading-overlay" style="display: none;">
+      <div class="spinner"></div>
+      <div>Loading...</div>
+    </div>
+  </main>
+  <script>
+    window.tableOverviewContext = {
+      csrfToken: "{{ csrf_token or '' }}",
+      defaultBranch: {% if default_branch %}{{ default_branch | tojson }}{% else %}null{% endif %},
+      hasBranches: {{ has_branches | tojson }},
+      branchCount: {{ (branches|length) if branches else 0 }},
+      tableCount: {{ (tables|length) if tables else 0 }}
+    };
+  </script>
+  <script src="/assets/restaurant_management/js/table_display.js"></script>
+</body>
+</html>

--- a/restaurant_management/www/internal_ui/waiter_order.html
+++ b/restaurant_management/www/internal_ui/waiter_order.html
@@ -1,150 +1,11 @@
-{% extends "templates/web.html" %}
-
-{% block title %}Waiter Order{% endblock %}
-
-{% block header %}
-{# Kosongkan header jika tidak ingin pakai default header #}
-{% endblock %}
-
-{% block page_content %}
-<!-- Loading overlay -->
-<div id="loading-overlay" class="fixed inset-0 hidden items-center justify-center bg-black/60 z-50">
-  <div class="text-white text-center">
-    <div class="spinner mb-2"></div>
-    <div>Loading...</div>
-  </div>
-</div>
-
-<!-- Main Content -->
-<div class="container mx-auto px-4 py-6">
-  <h1 class="text-2xl font-bold text-gray-900 mb-6">Waiter Order</h1>
-  
-  <!-- Error message section -->
-  {% if error_message %}
-  <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-6">
-    <p class="text-yellow-700">{{ error_message }}</p>
-  </div>
-  {% endif %}
-  
-  <!-- Branch Selection -->
-  {% if has_branches %}
-  <div class="mb-6">
-    <label for="branch-selector" class="block text-sm font-medium text-gray-700 mb-1">Branch</label>
-    <select id="branch-selector" class="w-full md:w-64 p-2 border rounded-md">
-      {% for branch in branches %}
-      <option value="{{ branch.branch_code or '' }}" {% if default_branch and branch.branch_code and default_branch.branch_code and branch.branch_code == default_branch.branch_code %}selected{% endif %}>
-        {{ branch.name or 'Unnamed Branch' }}
-      </option>
-      {% endfor %}
-    </select>
-  </div>
-  {% else %}
-  <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-6">
-    <p class="text-yellow-700">No branches available. Please contact your administrator.</p>
-  </div>
-  {% endif %}
-
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-    <!-- Left Panel: Table Selection -->
-    <div class="bg-white p-4 rounded-md shadow">
-      <h2 class="text-lg font-semibold mb-4">Tables</h2>
-      <div id="tables-container" class="grid grid-cols-3 gap-2">
-        {% if has_tables %}
-          <!-- Tables will be populated dynamically by JavaScript -->
-          <div class="col-span-3 text-center text-gray-500 py-4">Loading tables...</div>
-        {% else %}
-          <div class="col-span-3 text-center text-gray-500 py-4">No tables available</div>
-        {% endif %}
-      </div>
-      
-      <!-- New Order Form -->
-      <div class="mt-6 pt-4 border-t border-gray-200">
-        <h3 class="text-md font-semibold mb-2">New Order</h3>
-        <div class="flex">
-          <input type="text" id="new-order-table-number" placeholder="Table #" class="p-2 border rounded-md mr-2 flex-1" required>
-          <button id="new-order-btn" class="bg-green-600 text-white px-4 py-2 rounded-md">
-            Create
-          </button>
-        </div>
-      </div>
-    </div>
-    
-    <!-- Middle Panel: Menu Items -->
-    <div class="bg-white p-4 rounded-md shadow">
-      <h2 class="text-lg font-semibold mb-4">Menu</h2>
-      <div class="mb-4">
-        <input type="text" id="item-search" placeholder="Search items..." class="w-full p-2 border rounded-md">
-      </div>
-      
-      <!-- Item Category Tabs -->
-      <div class="nav-tabs flex flex-wrap mb-4 border-b">
-        {% if item_groups and item_groups|length > 0 %}
-          <!-- Item groups will be populated by JavaScript -->
-        {% else %}
-          <div class="p-2 text-gray-500">No item groups available</div>
-        {% endif %}
-      </div>
-      
-      <!-- Item List -->
-      <div id="items-section" class="overflow-y-auto max-h-96">
-        <ul id="item-list" class="space-y-2">
-          <li class="empty-message">Select a category or search for items</li>
-        </ul>
-      </div>
-    </div>
-    
-    <!-- Right Panel: Current Order -->
-    <div class="bg-white p-4 rounded-md shadow">
-      <h2 class="text-lg font-semibold mb-2">Order Summary</h2>
-      <p id="selected-table-display" class="text-sm text-gray-600 mb-4">No table selected</p>
-      
-      <!-- Order Items List -->
-      <div id="order-section" class="overflow-y-auto max-h-72">
-        <ul id="order-items" class="space-y-2 border-t pt-4">
-          <li class="empty-order-message">No items in order</li>
-        </ul>
-      </div>
-      
-      <!-- Order Actions -->
-      <div class="mt-6 space-y-2">
-        <button id="send-to-kitchen-btn" class="w-full bg-blue-600 text-white px-4 py-2 rounded-md disabled-btn">
-          Send to Kitchen
-        </button>
-        <button id="send-additional-btn" class="w-full bg-purple-600 text-white px-4 py-2 rounded-md disabled-btn">
-          Send Additional Items
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-
-<!-- Variant Selection Modal -->
-<div id="modal-overlay" class="fixed inset-0 hidden bg-black/50 z-40"></div>
-<div id="variant-modal" class="modal">
-    <div class="modal-content">
-        <h3 id="variant-item-name"></h3>
-        <div id="variant-attributes">
-            <!-- Dynamic attributes will be added here -->
-        </div>
-        <div class="modal-actions">
-            <button id="cancel-variant-btn" class="btn btn-secondary">Cancel</button>
-            <button id="add-variant-btn" class="btn btn-primary">Add to Order</button>
-        </div>
-    </div>
-</div>
-
-<!-- Confirmation Modal -->
-<div id="confirm-modal" class="fixed inset-0 hidden bg-black/50 z-50 flex items-center justify-center">
-  <div class="bg-white p-6 rounded-md shadow-lg w-full max-w-sm">
-    <p id="confirm-message" class="mb-4">Are you sure?</p>
-    <div class="flex justify-end space-x-2">
-      <button id="confirm-cancel" class="bg-gray-200 text-gray-800 px-4 py-2 rounded-md">Cancel</button>
-      <button id="confirm-ok" class="bg-blue-600 text-white px-4 py-2 rounded-md">OK</button>
-    </div>
-  </div>
-</div>
-
-<style>
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex">
+  <title>Waiter Order</title>
+  <style>
   .spinner {
     border: 4px solid rgba(255, 255, 255, 0.3);
     border-radius: 50%;
@@ -154,17 +15,17 @@
     animation: spin 1s linear infinite;
     margin: 0 auto;
   }
-  
+
   @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
   }
-  
+
   .disabled-btn {
     opacity: 0.6;
     cursor: not-allowed;
   }
-  
+
   .table-button {
     background-color: #f3f4f6;
     border: 1px solid #d1d5db;
@@ -173,12 +34,12 @@
     text-align: center;
     cursor: pointer;
   }
-  
+
   .table-button.selected {
     background-color: #dbeafe;
     border-color: #3b82f6;
   }
-  
+
   .item-button {
     background-color: #f3f4f6;
     border: 1px solid #d1d5db;
@@ -187,11 +48,11 @@
     cursor: pointer;
     margin-bottom: 0.5rem;
   }
-  
+
   .item-button:hover {
     background-color: #e5e7eb;
   }
-  
+
   .order-item {
     display: flex;
     justify-content: space-between;
@@ -200,22 +61,22 @@
     border: 1px solid #d1d5db;
     border-radius: 0.375rem;
   }
-  
+
   .order-item.sent-item {
     background-color: #f0fdf4;
     border-color: #86efac;
   }
-  
+
   .order-item-name {
     flex: 1;
   }
-  
+
   .order-item-qty {
     display: flex;
     align-items: center;
     margin-right: 1rem;
   }
-  
+
   .qty-btn {
     width: 1.5rem;
     height: 1.5rem;
@@ -226,35 +87,35 @@
     border-radius: 0.25rem;
     cursor: pointer;
   }
-  
+
   .order-item-remove {
     color: #ef4444;
     cursor: pointer;
     padding: 0 0.5rem;
   }
-  
+
   .nav-tab {
     padding: 0.5rem 1rem;
     cursor: pointer;
     border-bottom: 2px solid transparent;
   }
-  
+
   .nav-tab.active {
     border-bottom-color: #3b82f6;
     color: #3b82f6;
   }
-  
+
   .error {
     border-color: #ef4444;
   }
-  
+
   .empty-message, .empty-order-message {
     color: #6b7280;
     padding: 1rem;
     text-align: center;
     font-style: italic;
   }
-  
+
   .modal {
     display: none;
     position: fixed;
@@ -268,11 +129,11 @@
     max-width: 500px;
     box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
   }
-  
+
   .modal-content {
     padding: 1.5rem;
   }
-  
+
   .modal-actions {
     display: flex;
     justify-content: flex-end;
@@ -281,34 +142,140 @@
     border-top: 1px solid #e5e7eb;
     padding-top: 1rem;
   }
-  
+
   .btn {
     padding: 0.5rem 1rem;
     border-radius: 0.375rem;
     font-weight: 500;
   }
-  
+
   .btn-primary {
     background-color: #3b82f6;
     color: white;
   }
-  
+
   .btn-secondary {
     background-color: #e5e7eb;
     color: #1f2937;
   }
-</style>
-{% endblock %}
-
-{% block script %}
-<script>
-  window.waiterOrderContext = {
-    csrfToken: "{{ csrf_token or '' }}",
-    defaultBranch: {% if default_branch %}{{ default_branch | tojson }}{% else %}null{% endif %},
-    hasBranches: {{ has_branches | tojson }},
-    hasTables: {{ has_tables | tojson }},
-    userRole: "{{ user or '' }}"
-  };
-</script>
-<script type="text/javascript" src="/assets/restaurant_management/js/waiter_order.js" defer></script>
-{% endblock %}
+  </style>
+</head>
+<body>
+  <div id="loading-overlay" class="fixed inset-0 hidden items-center justify-center bg-black/60 z-50">
+    <div class="text-white text-center">
+      <div class="spinner mb-2"></div>
+      <div>Loading...</div>
+    </div>
+  </div>
+  <main class="container mx-auto px-4 py-6">
+    <h1 class="text-2xl font-bold text-gray-900 mb-6">Waiter Order</h1>
+    {% if error_message %}
+    <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-6">
+      <p class="text-yellow-700">{{ error_message }}</p>
+    </div>
+    {% endif %}
+    {% if has_branches %}
+    <div class="mb-6">
+      <label for="branch-selector" class="block text-sm font-medium text-gray-700 mb-1">Branch</label>
+      <select id="branch-selector" class="w-full md:w-64 p-2 border rounded-md">
+        {% for branch in branches %}
+        <option value="{{ branch.branch_code or '' }}" {% if default_branch and branch.branch_code and default_branch.branch_code and branch.branch_code == default_branch.branch_code %}selected{% endif %}>
+          {{ branch.name or 'Unnamed Branch' }}
+        </option>
+        {% endfor %}
+      </select>
+    </div>
+    {% else %}
+    <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-6">
+      <p class="text-yellow-700">No branches available. Please contact your administrator.</p>
+    </div>
+    {% endif %}
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div class="bg-white p-4 rounded-md shadow">
+        <h2 class="text-lg font-semibold mb-4">Tables</h2>
+        <div id="tables-container" class="grid grid-cols-3 gap-2">
+          {% if has_tables %}
+            <div class="col-span-3 text-center text-gray-500 py-4">Loading tables...</div>
+          {% else %}
+            <div class="col-span-3 text-center text-gray-500 py-4">No tables available</div>
+          {% endif %}
+        </div>
+        <div class="mt-6 pt-4 border-t border-gray-200">
+          <h3 class="text-md font-semibold mb-2">New Order</h3>
+          <div class="flex">
+            <input type="text" id="new-order-table-number" placeholder="Table #" class="p-2 border rounded-md mr-2 flex-1" required>
+            <button id="new-order-btn" class="bg-green-600 text-white px-4 py-2 rounded-md">
+              Create
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="bg-white p-4 rounded-md shadow">
+        <h2 class="text-lg font-semibold mb-4">Menu</h2>
+        <div class="mb-4">
+          <input type="text" id="item-search" placeholder="Search items..." class="w-full p-2 border rounded-md">
+        </div>
+        <div class="nav-tabs flex flex-wrap mb-4 border-b">
+          {% if item_groups and item_groups|length > 0 %}
+          {% else %}
+            <div class="p-2 text-gray-500">No item groups available</div>
+          {% endif %}
+        </div>
+        <div id="items-section" class="overflow-y-auto max-h-96">
+          <ul id="item-list" class="space-y-2">
+            <li class="empty-message">Select a category or search for items</li>
+          </ul>
+        </div>
+      </div>
+      <div class="bg-white p-4 rounded-md shadow">
+        <h2 class="text-lg font-semibold mb-2">Order Summary</h2>
+        <p id="selected-table-display" class="text-sm text-gray-600 mb-4">No table selected</p>
+        <div id="order-section" class="overflow-y-auto max-h-72">
+          <ul id="order-items" class="space-y-2 border-t pt-4">
+            <li class="empty-order-message">No items in order</li>
+          </ul>
+        </div>
+        <div class="mt-6 space-y-2">
+          <button id="send-to-kitchen-btn" class="w-full bg-blue-600 text-white px-4 py-2 rounded-md disabled-btn">
+            Send to Kitchen
+          </button>
+          <button id="send-additional-btn" class="w-full bg-purple-600 text-white px-4 py-2 rounded-md disabled-btn">
+            Send Additional Items
+          </button>
+        </div>
+      </div>
+    </div>
+  </main>
+  <div id="modal-overlay" class="fixed inset-0 hidden bg-black/50 z-40"></div>
+  <div id="variant-modal" class="modal">
+      <div class="modal-content">
+          <h3 id="variant-item-name"></h3>
+          <div id="variant-attributes">
+          </div>
+          <div class="modal-actions">
+              <button id="cancel-variant-btn" class="btn btn-secondary">Cancel</button>
+              <button id="add-variant-btn" class="btn btn-primary">Add to Order</button>
+          </div>
+      </div>
+  </div>
+  <div id="confirm-modal" class="fixed inset-0 hidden bg-black/50 z-50 flex items-center justify-center">
+    <div class="bg-white p-6 rounded-md shadow-lg w-full max-w-sm">
+      <p id="confirm-message" class="mb-4">Are you sure?</p>
+      <div class="flex justify-end space-x-2">
+        <button id="confirm-cancel" class="bg-gray-200 text-gray-800 px-4 py-2 rounded-md">Cancel</button>
+        <button id="confirm-ok" class="bg-blue-600 text-white px-4 py-2 rounded-md">OK</button>
+      </div>
+    </div>
+  </div>
+  <script>
+    window.waiterOrderContext = {
+      csrfToken: "{{ csrf_token or '' }}",
+      defaultBranch: {% if default_branch %}{{ default_branch | tojson }}{% else %}null{% endif %},
+      hasBranches: {{ has_branches | tojson }},
+      hasTables: {{ has_tables | tojson }},
+      userRole: "{{ user or '' }}"
+    };
+  </script>
+  <script type="text/javascript" src="/assets/restaurant_management/js/waiter_order.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- convert station_display, table_display and waiter_order templates to standalone HTML
- add `<meta name="robots" content="noindex">` for SEO safety

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687523ae002c832cb4d5c9d9a5c46fa4