### PR TITLE
Set no_wrapper flag for UI pages

### DIFF
--- a/restaurant_management/www/internal_ui/station_display.py
+++ b/restaurant_management/www/internal_ui/station_display.py
@@ -117,4 +117,5 @@ def get_context(context=None):
         context.is_guest = frappe.session.user == "Guest"
         context.error_message = _("Unable to load kitchen station data. Please check error logs.")
     
+    context.no_wrapper = 1
     return context

--- a/restaurant_management/www/internal_ui/table_display.py
+++ b/restaurant_management/www/internal_ui/table_display.py
@@ -109,4 +109,5 @@ def get_context(context=None):
         context.default_branch = None
         context.error_message = _("Unable to load table data. Please check error logs.")
     
+    context.no_wrapper = 1
     return context

--- a/restaurant_management/www/internal_ui/waiter_order.py
+++ b/restaurant_management/www/internal_ui/waiter_order.py
@@ -137,4 +137,5 @@ def get_context(context=None):
         context.default_branch = None
         context.error_message = _("Unable to load waiter order page. Please check error logs.")
     
+    context.no_wrapper = 1
     return context


### PR DESCRIPTION
## Summary
- avoid rendering the website wrapper on custom pages

## Testing
- `python -m py_compile restaurant_management/www/internal_ui/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752763355c832ca971ebb078843590