### PR TITLE
Add table display CSS asset

### DIFF
--- a/restaurant_management/hooks.py
+++ b/restaurant_management/hooks.py
@@ -16,7 +16,8 @@ web_include_js = [
 ]
 
 web_include_css = [
-    "/assets/restaurant_management/css/waiter_order.css"
+    "/assets/restaurant_management/css/waiter_order.css",
+    "/assets/restaurant_management/css/table_display.css",
 ]
 
 # Override Doctype Classes

--- a/restaurant_management/public/css/table_display.css
+++ b/restaurant_management/public/css/table_display.css
@@ -1,0 +1,89 @@
+.tables-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 15px;
+  padding: 15px;
+}
+.table-card {
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  padding: 15px;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  position: relative;
+  overflow: hidden;
+}
+.table-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+}
+.table-number {
+  font-size: 1.4rem;
+  font-weight: bold;
+}
+.table-status {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin: 10px;
+}
+.table-info {
+  margin-top: 10px;
+  font-size: 0.9rem;
+}
+.table-info p {
+  margin: 5px 0;
+}
+.waiter-name {
+  font-style: italic;
+}
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0,0,0,0.5);
+  display: none;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  color: white;
+  flex-direction: column;
+}
+.spinner {
+  border: 4px solid rgba(255,255,255,0.3);
+  border-radius: 50%;
+  border-top: 4px solid white;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+  margin-bottom: 10px;
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+.branch-code-container {
+  margin: 15px;
+}
+.refresh-container {
+  display: flex;
+  align-items: center;
+  margin: 0 15px 15px;
+  font-size: 0.9rem;
+}
+.capacity-indicator {
+  display: inline-block;
+  margin-left: 5px;
+  font-size: 0.8rem;
+}
+.empty-state {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 30px;
+  color: #7f8c8d;
+}


### PR DESCRIPTION
## Summary
- add table_display.css with basic styles
- include table_display.css in hooks for Frappe build

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687535c0d564832c9de88c8a22b78bb2