### PR TITLE
Add variant attribute support

### DIFF
--- a/restaurant_management/api/waiter_order.py
+++ b/restaurant_management/api/waiter_order.py
@@ -376,6 +376,14 @@ def add_items_to_order(order_doc, items_list):
         if not rate:
             rate = get_item_rate(item_data.get("item_code"))
         
+        # Parse variant attributes if provided
+        variant_attrs = item_data.get("variant_attributes") or item_data.get("attributes")
+        if isinstance(variant_attrs, str):
+            try:
+                variant_attrs = json.loads(variant_attrs)
+            except Exception:
+                variant_attrs = None
+
         # Add item to order
         item = order_doc.append("items", {
             "item_code": item_data.get("item_code"),
@@ -386,7 +394,8 @@ def add_items_to_order(order_doc, items_list):
             "status": "New",
             "ordered_by": frappe.session.user,
             "last_update_by": frappe.session.user,
-            "last_update_time": now_datetime()
+            "last_update_time": now_datetime(),
+            "variant_attributes": variant_attrs or None,
         })
         
         # Set amount based on rate and qty

--- a/restaurant_management/public/js/waiter_order.js
+++ b/restaurant_management/public/js/waiter_order.js
@@ -334,19 +334,19 @@ frappe.ready(() => {
 
     elements.orderItemsContainer.innerHTML = state.currentOrder.items.map((orderItem, index) => {
       const isSent = state.currentOrder.sentItems.some(
-        sent => sent.item_code === orderItem.item_code && 
-                JSON.stringify(sent.attributes || {}) === JSON.stringify(item.attributes || {})
+        sent => sent.item_code === orderItem.item_code &&
+                JSON.stringify(sent.variant_attributes || {}) === JSON.stringify(orderItem.variant_attributes || {})
       );
       
       // Calculate and display amount
       const amount = (orderItem.rate || 0) * (orderItem.qty || 0);
       
       // Format attributes for display
-      const attributesDisplay = orderItem.attributes ? 
-        '<div class="item-attributes">' + 
-        Object.entries(orderItem.attributes)
+      const attributesDisplay = orderItem.variant_attributes ?
+        '<div class="item-attributes">' +
+        Object.entries(orderItem.variant_attributes)
           .map(([k, v]) => `<span class="attribute-badge">${k}: ${v}</span>`)
-          .join(' ') + 
+          .join(' ') +
         '</div>' : '';
       
       return `
@@ -402,10 +402,10 @@ frappe.ready(() => {
 
     // "Send Additional Items" button is active if there are new items not yet sent
     if (elements.sendAdditionalBtn) {
-      const hasNewItems = state.currentOrder.items.some(item => 
+      const hasNewItems = state.currentOrder.items.some(item =>
         !state.currentOrder.sentItems.some(
-          sent => sent.item_code === item.item_code && 
-                  JSON.stringify(sent.attributes || {}) === JSON.stringify(item.attributes || {})
+          sent => sent.item_code === item.item_code &&
+                  JSON.stringify(sent.variant_attributes || {}) === JSON.stringify(item.variant_attributes || {})
         )
       );
 
@@ -664,10 +664,10 @@ frappe.ready(() => {
       return;
     }
     
-    const newItems = state.currentOrder.items.filter(item => 
+    const newItems = state.currentOrder.items.filter(item =>
       !state.currentOrder.sentItems.some(
-        sent => sent.item_code === item.item_code && 
-                JSON.stringify(sent.attributes || {}) === JSON.stringify(item.attributes || {})
+        sent => sent.item_code === item.item_code &&
+                JSON.stringify(sent.variant_attributes || {}) === JSON.stringify(item.variant_attributes || {})
       )
     );
     
@@ -913,7 +913,7 @@ frappe.ready(() => {
           item_name: displayName,
           variant_of: state.selectedItemTemplate.item_code,
           rate: variantRate,
-          attributes: attributes
+          variant_attributes: attributes
         });
         
         // Show success message
@@ -938,9 +938,9 @@ frappe.ready(() => {
   // Helper: Add item to order
   const addItemToOrder = (item) => {
     // Check if this exact item (including attributes) already exists
-    const existingItemIndex = state.currentOrder.items.findIndex(orderItem => 
-      orderItem.item_code === item.item_code && 
-      JSON.stringify(orderItem.attributes || {}) === JSON.stringify(item.attributes || {})
+    const existingItemIndex = state.currentOrder.items.findIndex(orderItem =>
+      orderItem.item_code === item.item_code &&
+      JSON.stringify(orderItem.variant_attributes || {}) === JSON.stringify(item.variant_attributes || {})
     );
     
     if (existingItemIndex !== -1) {
@@ -954,7 +954,7 @@ frappe.ready(() => {
         variant_of: item.variant_of || null,
         rate: item.rate || 0,
         qty: 1,
-        attributes: item.attributes || null
+        variant_attributes: item.variant_attributes || item.attributes || null
       });
     }
     


### PR DESCRIPTION
## Summary
- handle `variant_attributes` input when creating waiter order items
- send selected variant attributes from the waiter order page

## Testing
- `python -m py_compile restaurant_management/api/waiter_order.py`
- `node -c restaurant_management/public/js/waiter_order.js`


------
https://chatgpt.com/codex/tasks/task_e_687537d45978832caafe27199c88dd0c