### PR TITLE
Update table display overlay visibility

### DIFF
--- a/restaurant_management/www/internal_ui/table_display.html
+++ b/restaurant_management/www/internal_ui/table_display.html
@@ -73,7 +73,7 @@
       </div>
     </div>
     <!-- Loading overlay -->
-    <div id="loading-overlay" class="loading-overlay" style="display: none;">
+    <div id="loading-overlay" class="loading-overlay">
       <div class="spinner"></div>
       <div>Loading...</div>
     </div>


### PR DESCRIPTION
## Summary
- remove the inline `display: none` from the loading overlay in `table_display.html`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876371b657c832c9078ed650e721fc1