### PR TITLE
Enforce valid waiter order status transitions

### DIFF
--- a/restaurant_management/order_status.py
+++ b/restaurant_management/order_status.py
@@ -1,0 +1,14 @@
+"""Utilities for handling Waiter Order status transitions."""
+
+VALID_STATUS_TRANSITIONS = {
+    "Draft": ["Confirmed", "Cancelled"],
+    "Confirmed": ["Served", "Cancelled"],
+    "Served": ["Paid", "Cancelled"],
+    "Paid": [],
+    "Cancelled": [],
+}
+
+
+def is_valid_status_transition(current: str, new: str) -> bool:
+    """Return True if transition from current to new is allowed."""
+    return new in VALID_STATUS_TRANSITIONS.get(current, [])

--- a/restaurant_management/restaurant_management/doctype/waiter_order/test_waiter_order.py
+++ b/restaurant_management/restaurant_management/doctype/waiter_order/test_waiter_order.py
@@ -1,0 +1,14 @@
+import pytest
+from restaurant_management.order_status import is_valid_status_transition
+
+
+def test_valid_status_transitions():
+    assert is_valid_status_transition("Draft", "Confirmed")
+    assert is_valid_status_transition("Confirmed", "Served")
+    assert is_valid_status_transition("Served", "Paid")
+
+
+def test_invalid_status_transitions():
+    assert not is_valid_status_transition("Draft", "Paid")
+    assert not is_valid_status_transition("Paid", "Confirmed")
+    assert not is_valid_status_transition("Cancelled", "Draft")

--- a/restaurant_management/restaurant_management/doctype/waiter_order/waiter_order.py
+++ b/restaurant_management/restaurant_management/doctype/waiter_order/waiter_order.py
@@ -2,9 +2,13 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import now_datetime
-from restaurant_management.restaurant_management.doctype.table.table import update_table_status
+from restaurant_management.restaurant_management.doctype.table.table import (
+    update_table_status,
+)
+from restaurant_management.order_status import is_valid_status_transition
 
 
 class WaiterOrder(Document):
@@ -72,10 +76,21 @@ class WaiterOrder(Document):
         
         # Validate all order items
         self.validate_order_items()
-            
+
+        # Validate status transition
+        if not self.is_new():
+            previous_status = frappe.db.get_value(self.doctype, self.name, "status")
+            if previous_status and previous_status != self.status:
+                if not is_valid_status_transition(previous_status, self.status):
+                    frappe.throw(
+                        _(f"Invalid status transition from {previous_status} to {self.status}")
+                    )
+
         # Update table status when order status changes to Paid
         if self.status == "Paid" and self.table:
-            logger.info(f"Order {self.name} marked as Paid, updating table {self.table}")
+            logger.info(
+                f"Order {self.name} marked as Paid, updating table {self.table}"
+            )
             update_table_status(self.table, "Available", None)
     
     def validate_order_items(self):


### PR DESCRIPTION
## Summary
- ensure `update_order_status` checks status changes against allowed transitions
- centralize valid status transitions with helper utility used by WaiterOrder
- add unit tests covering valid and invalid status transitions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689761f6af0c832c8de04a557c185da9