### PR TITLE
Use local JS paths in internal UI

### DIFF
--- a/restaurant_management/www/internal_ui/station_display.html
+++ b/restaurant_management/www/internal_ui/station_display.html
@@ -114,6 +114,6 @@
       isGuest: {{ is_guest | tojson }}
     };
   </script>
-  <script defer src="../station_display.js"></script>
+  <script defer src="./station_display.js"></script>
 </body>
 </html>

--- a/restaurant_management/www/internal_ui/table_display.html
+++ b/restaurant_management/www/internal_ui/table_display.html
@@ -87,6 +87,6 @@
       tableCount: {{ (tables|length) if tables else 0 }}
     };
   </script>
-  <script src="../table_display.js"></script>
+  <script src="./table_display.js"></script>
 </body>
 </html>

--- a/restaurant_management/www/internal_ui/waiter_order.html
+++ b/restaurant_management/www/internal_ui/waiter_order.html
@@ -123,6 +123,6 @@
       userRole: "{{ user or '' }}"
     };
   </script>
-  <script type="text/javascript" src="../waiter_order.js" defer></script>
+  <script type="text/javascript" src="./waiter_order.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load waiter, station, and table scripts from local directory instead of asset path

## Testing
- `pytest`
- `python -m http.server 8000` and `curl -I http://localhost:8000/waiter_order.html`
- `python -m http.server 8000` and `curl -I http://localhost:8000/station_display.html`
- `python -m http.server 8000` and `curl -I http://localhost:8000/table_display.html`


------
https://chatgpt.com/codex/tasks/task_e_68976c24e5d4832c85fe8ebfdd2d29a2