### PR TITLE
Filter menu items by branch

### DIFF
--- a/restaurant_management/restaurant_management/doctype/waiter_order/waiter_order.py
+++ b/restaurant_management/restaurant_management/doctype/waiter_order/waiter_order.py
@@ -274,11 +274,22 @@ def get_menu_items(branch=None, show_variants=False):
         List of menu items
     """
     filters = {"disabled": 0}
-    
+
     # If branch is specified, filter items by branch
     if branch:
-        # Add branch-specific filter logic here if needed
-        pass
+        # Get items explicitly mapped to the given branch
+        branch_items = frappe.get_all(
+            "Item Branch",
+            filters={"branch": branch},
+            fields=["parent"],
+        )
+
+        # If no items are mapped to this branch, return empty list
+        if not branch_items:
+            return []
+
+        # Filter Item query to only include items available in the branch
+        filters["name"] = ["in", [d.parent for d in branch_items]]
     
     # If not showing variants, exclude items that are variants of other items
     if not frappe.utils.cint(show_variants):


### PR DESCRIPTION
## Summary
- Filter waiter order menu items by branch using Item Branch mappings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689772625620832cb171ce6fcbd2ec44